### PR TITLE
docs: point documentation at new Rust on ESP Book URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ possible. I give no guarantee that this is the correct usage of the hardware, us
 ## Usage
 
 1. Prepare your development requirement according to
-   this [guide](https://docs.esp-rs.org/book/installation/riscv-and-xtensa.html).
-2. Create a new project, I recommend using `cargo-generate` and
-   the [template](https://docs.esp-rs.org/book/writing-your-own-application/generate-project/index.html) provided
-   by `esp-rs` (i.e. `cargo generate esp-rs/esp-template`)
+   this [guide](https://docs.espressif.com/projects/rust/book/getting-started/toolchain.html).
+2. Create a new project, I recommend using `esp-generate` and
+   the [template](https://docs.espressif.com/projects/rust/book/getting-started/using-esp-generate.html) provided
+   by `esp-rs`.
 3. Use the following template for your application and adopt for your needs.
 
 ```rust


### PR DESCRIPTION
The original domain used for the Rust on ESP book hosts ads for gambling now. The documentation has changed a bit and is now over at [docs.espressif.com](https://docs.espressif.com/projects/rust/book/getting-started/index.html). 

I have pointed the relevant links to the new domain, but the step for generating a project from a template has changed a bit, so I changed the contents there too. I have not checked those steps though.